### PR TITLE
Freeze gojs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "typescript": "^3.3.3333"
     },
     "dependencies": {
-        "gojs": "^1.8.29"
+        "gojs": "1.8.29"
     },
     "peerDependencies": {
         "react": "16.x",


### PR DESCRIPTION
This freezes the version of core dependency => gojs, to 1.8.29